### PR TITLE
근무체크 기능 추가 

### DIFF
--- a/src/main/java/com/kdt/controllers/WorkController.java
+++ b/src/main/java/com/kdt/controllers/WorkController.java
@@ -48,12 +48,29 @@ public class WorkController {
 	public List<WorkTimesDTO> insert(WorkTimesDTO dto,Model model)throws Exception {
 		String ID = (String) session.getAttribute("loginId");
 		dto.setId(ID);
-
-		System.out.println(dto.getId()+dto.getWork_type()+dto.getWork_time());
-		wservice.insert(dto);
+		int today = wservice.existstoday(ID);
+		System.out.println(today);
+		if(today==0 && dto.getWork_type().equals("근무중")) { // 09시 이후 출근 클릭
+			wservice.insert(dto);
+			wservice.addworklate(ID);
 		List<WorkTimesDTO> tlist = wservice.selectby(ID);
 		model.addAttribute("tlist",tlist);
 		return tlist;
+		}
+		else if(today==0 && dto.getWork_type().equals("근무 종료")) { // 18시 이전 퇴근 클릭
+			wservice.insert(dto);
+			wservice.addworkearly(ID);
+		List<WorkTimesDTO> tlist = wservice.selectby(ID);
+		model.addAttribute("tlist",tlist);
+		return tlist;
+		}
+		else {
+			wservice.insert(dto);
+			List<WorkTimesDTO> tlist = wservice.selectby(ID);
+			model.addAttribute("tlist",tlist);
+			return tlist;
+		}
+		
 	}
 	@ResponseBody
 	@RequestMapping("list") // 근무현황판 출력

--- a/src/main/java/com/kdt/dao/WorksDAO.java
+++ b/src/main/java/com/kdt/dao/WorksDAO.java
@@ -66,5 +66,14 @@ public class WorksDAO {
 	public int updateLeaveRemainder(LeavesDTO dto)throws Exception{
 		return db.update("Leaves.updateLeaveRemainder",dto);
 	}
+	public int existstoday(String ID)throws Exception{
+		return db.selectOne("Works.existstoday",ID);
+	}
+	public int addworklate(String ID)throws Exception{
+		return db.update("Works.addworklate",ID);
+	}
+	public int addworkearly(String ID)throws Exception{
+		return db.update("Works.addworkearly",ID);
+	}
 	
 }

--- a/src/main/java/com/kdt/dto/WorksDTO.java
+++ b/src/main/java/com/kdt/dto/WorksDTO.java
@@ -98,6 +98,23 @@ public class WorksDTO {
 	public void setAll_worktime(int all_worktime) {
 		this.all_worktime = all_worktime;
 	}
+	public String getAveragehours() {
+		 
+			  int averageMinutes = all_worktime / 60;
+		 String formattedAverageTime = String.format("%02d", averageMinutes);
+		return  formattedAverageTime;
+		 }
+		
+	
+	
+	public String getAverageminute() {
+		 
+			  int averageMinutes = all_worktime % 60;
+		 String formattedAverageTime = String.format("%02d", averageMinutes);
+		return  formattedAverageTime;
+		 }
+		
+	
 	
 	
 }

--- a/src/main/java/com/kdt/services/WorksService.java
+++ b/src/main/java/com/kdt/services/WorksService.java
@@ -126,4 +126,13 @@ public void updateLeaveRemainder(String idList, String joindayList) throws Excep
 	    }
 	    return;
 	}
+public int existstoday(String ID)throws Exception{
+	return wdao.existstoday(ID);
+}
+public int addworklate(String ID)throws Exception{
+	return wdao.addworklate(ID);
+}
+public int addworkearly(String ID)throws Exception{
+	return wdao.addworkearly(ID);
+}
 }

--- a/src/main/resources/mappers/works-mapper.xml
+++ b/src/main/resources/mappers/works-mapper.xml
@@ -19,4 +19,17 @@
   <update id="update">
 		Update Works set organization = #{organization} where id = #{id};
 	</update>
+	<select id="existstoday" resultType="Int">
+		SELECT count(*) FROM WorkPlan WHERE id = #{id} AND DATE(work_day) = CURDATE();
+	</select>
+	<update id="addworklate">
+	<![CDATA[
+	UPDATE Works SET work_late = work_late + 1 WHERE id = #{id} AND TIME(CONVERT_TZ(now(), 'UTC', 'Asia/Seoul')) > '09:00:00';
+	]]>
+	</update>
+	<update id="addworkearly">
+	<![CDATA[
+		UPDATE Works SET work_early = work_early + 1 WHERE id = #{id} AND TIME(CONVERT_TZ(now(), 'UTC', 'Asia/Seoul')) < '18:00:00';
+	]]>
+	</update>
   </mapper>

--- a/src/main/resources/static/css/insa/work_manage/workmanage.css
+++ b/src/main/resources/static/css/insa/work_manage/workmanage.css
@@ -2,14 +2,15 @@ thead tr {
 	background-color: #EFF4FC;
 }
 .right_item{
-	width: calc(0% - 276px)!important;
-    height: calc(70% - 60px)!important;
+	min-width:600px !important;
+	height: calc(40% - 60px)!important;
 }
 .modal {
+	width: calc(0% - 276px)!important;
 	display: none;
 	position: fixed;
-	top: 20%;
-	left: 5%;
+	top: 30%;
+	left: 25%;
 	padding: 20px;
 	background-color: #fff;
 	border: 1px solid #ccc;

--- a/src/main/resources/static/js/insa/work_manage/workmanage.js
+++ b/src/main/resources/static/js/insa/work_manage/workmanage.js
@@ -21,7 +21,7 @@ $(document).ready(function() {
 		$('.joinday').each(function() {
 			const inputValue = $(this).val().trim();
 			// 정규 표현식을 사용하여 YYYY-MM-DD 형식 확인
-			const regex = /^(2000|20[01]\d|2023)-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+			const regex = /^(2000|20[01]\d|202[0-2]|2023)-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
 			if (inputValue !== "" && regex.test(inputValue)) {
 				const correspondingId = $(this).closest('tr').find('.id').val();
 				idbox.push(correspondingId);
@@ -83,7 +83,7 @@ function updateWorkformTable() {
 				"</td><td>" + (resp[i].remainder_leave) + "</td></tr>")
 			$("#workbox").append(tr);
 		}
-		$(".div").after("총 인원 :" + resp.length);
+		$(".div").append("총 인원 :" + resp.length);
 	});
 }
 

--- a/src/main/webapp/WEB-INF/jsp/insa/mywork/work_leave.jsp
+++ b/src/main/webapp/WEB-INF/jsp/insa/mywork/work_leave.jsp
@@ -73,7 +73,7 @@
 							<span>근무 일수</span> <br> <br> ${i.all_workday}일
 						</div>
 						<div class="allworktile">
-							<span>총 근무 시간</span> <br> <br> ${i.all_worktime }시간
+							<span>총 근무 시간</span> <br> <br> ${i.averagehours }:${i.averageminute } 시간
 						</div>
 					</div>
 				</div>

--- a/src/main/webapp/WEB-INF/jsp/insa/work_manage/workmanage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/insa/work_manage/workmanage.jsp
@@ -45,9 +45,10 @@
 				</tbody>
 			</table>
 			<div class="div">
-				<span><button id="openModalBtn">휴가 미생성자</button></span>
+				 <span style="float: right;"><button id="openModalBtn">휴가 미생성자</button></span>
 			</div>
-
+<c:choose>
+<c:when test="${not empty list}">
 			<div id="myModal" class="modal right_item">
 				<h3>휴가 미생성자</h3>
 				<hr>
@@ -57,30 +58,76 @@
 					<table border="1" style="width: 100%;">
 						<thead>
 							<tr>
-								<th>이름(ID)</th>
-								<th>입사일</th>
+								<th style="text-align: center;">이름(ID)</th>
+								<th style="text-align: center;">입사일</th>
 							</tr>
 						</thead>
 						<tbody>
-							<c:forEach var="i" items="${list}">
-								<tr>
-									<td>${i.name}(${i.id })</td>
-									<td><input type="text" name="idList" class="idListbox"
-										hidden> <input type="text" name="joindayList"
-										class="joindayListbox" hidden> <input type="hidden"
-										class="id" value="${i.id}">
-										<div class="input-group mb-0">
-											<input type="text" name="name" class="form-control joinday" placeholder="YYYY-MM-DD" id="modal_body_content_input_right_name" style="font-size: 14px; height: 34px; width: 338px; padding: 0 10px;" maxlength="50">
-										</div></td>
-								</tr>
-							</c:forEach>
+								
+									<c:forEach var="i" items="${list}">
+										<tr>
+											<td style="text-align: center;">${i.name}(${i.id})</td>
+											<td style="text-align: center;"><input type="text" name="idList" class="idListbox"
+												hidden> <input type="text" name="joindayList"
+												class="joindayListbox" hidden> <input type="hidden"
+												class="id" value="${i.id}">
+												<div class="input-group mb-0">
+													<input type="text" name="name" class="form-control joinday"
+														placeholder="YYYY-MM-DD"
+														id="modal_body_content_input_right_name"
+														style="font-size: 14px; height: 34px; width: 338px; padding: 0 10px;"
+														maxlength="50">
+												</div></td>
+										</tr>
+									</c:forEach>
+								
+								
+							
 						</tbody>
 					</table>
+					<div style="text-align: center;">
 					<button id="leaveCreationForm" type="submit" class="button_apply">생성</button>
 					<button id="closeModalBtn">취소</button>
+					</div>
 				</form>
 			</div>
 			<div id="overlay" class="overlay"></div>
+			</c:when>
+			<c:otherwise><div id="myModal" class="modal right_item">
+				<h3>휴가 미생성자</h3>
+				<hr>
+				<!-- action 및 method 추가 -->
+				<form action="/works/joindayupdate">
+					입사일을 입력하고 생성을 클릭하면, 해당 사용자의 올해 휴가가 생성됩니다.
+					<table border="1" style="width: 100%;">
+						<thead>
+							<tr>
+								<th style="text-align: center;">이름(ID)</th>
+								<th style="text-align: center;">입사일</th>
+							</tr>
+						</thead>
+						<tbody>
+								
+									<tr>
+								<td colspan="2">
+								<div style="text-align: center;">휴가 미생성자가 없습니다</div>
+								</td>
+								</tr>
+								
+								
+							
+						</tbody>
+					</table>
+					<div style="text-align: center;">
+					<button id="leaveCreationForm" type="submit" class="button_apply permit">생성</button>
+					<button id="closeModalBtn">취소</button>
+					</div>
+				</form>
+			</div>
+			<div id="overlay" class="overlay"></div>
+								
+								</c:otherwise>
+</c:choose>
 
 			<script src="/js/insa/work_manage/workmanage.js"></script>
 		</div>


### PR DESCRIPTION
휴가/근무 페이지
근무현황 >
 스크롤 css 추가했습니다.
근무현황을 출력할 때 border가 있던 것을 제거했습니다.
근무체크>  
이제 마지막으로 하고있던 임무가 출력됩니다.
 이제 마지막으로 하고있던 임무의 버튼이 비활성화 됩니다.
근무시간>
총근무시간 00:00 시간 형식으로 출력됩니다.

근태현황>
정시 출근이고 출근을 클릭했을 때 9시 이후라면 지각 횟수가 1회 추가됩니다.
정시 출근이고 퇴근을 클릭했을 때 18시 이전이라면 조기 퇴근이 1회 추가됩니다.
전사근무관리 페이지
휴가 미생성자 modal창을 띄웠을때 미생성자가 없다면 문구가 출력되고 생성버튼 클릭이 불가능 합니다.
