### PR TITLE
기능 수정

### DIFF
--- a/src/main/java/com/kdt/controllers/WorkController.java
+++ b/src/main/java/com/kdt/controllers/WorkController.java
@@ -95,6 +95,12 @@ public class WorkController {
 		model.addAttribute("tlist",tlist);
 		return tlist;
 	}
+	@ResponseBody
+	@RequestMapping("workplanlist") // 근무현황판 출력
+	public String workplanlist(Model model)throws Exception  {
+		MembersDTO userDTO = (MembersDTO) session.getAttribute("userDTO");
+		return wservice.selectbyname(userDTO.getName());
+	}
 	
 	@ResponseBody
 	@RequestMapping("work_inout") // 출근시간 퇴근시간 시간 출력

--- a/src/main/java/com/kdt/dao/WorksDAO.java
+++ b/src/main/java/com/kdt/dao/WorksDAO.java
@@ -89,5 +89,8 @@ public class WorksDAO {
 	public List<WorkPlanDTO> work_current_selectByName(String name)throws Exception{
 		return db.selectList("Works.work_current_selectByName",name);
 	}
+	public String selectbyname(String name)throws Exception{
+		return db.selectOne("Works.selectbyname",name);
+	}
 	
 }

--- a/src/main/java/com/kdt/services/WorksService.java
+++ b/src/main/java/com/kdt/services/WorksService.java
@@ -149,4 +149,7 @@ public int addworkminutetime(String ID)throws Exception{
 public int addworknotcheck(String ID)throws Exception{
 	return wdao.addworknotcheck(ID);
 }
+public String selectbyname(String name)throws Exception{
+	return wdao.selectbyname(name);
+}
 }

--- a/src/main/resources/mappers/works-mapper.xml
+++ b/src/main/resources/mappers/works-mapper.xml
@@ -74,4 +74,7 @@ WHERE id=#{id};
 	<select id="work_current_selectByName" resultType="com.kdt.dto.WorkPlanDTO">
 		SELECT * FROM WorkPlan WHERE user_names = #{name} and approval_status='완료';
 	</select>
+	<select id="selectbyname" resultType="String">
+		SELECT work_types FROM WorkPlan WHERE user_names = #{name} AND approval_status = '완료' AND STR_TO_DATE(work_days, '%Y년%m월%d일') = CURDATE();
+	</select>
   </mapper>

--- a/src/main/resources/static/css/insa/mywork/work_leave.css
+++ b/src/main/resources/static/css/insa/mywork/work_leave.css
@@ -161,11 +161,42 @@
     }
 
     .workplanbox {
-
+		padding-top: 50px;
     	border-radius: 4px;
     	height: 400px;
     	border: 1px solid black;
     }
+    .calendar_icon{
+		
+        background-color:#8fa6c9;
+        width: 50%;
+        height: 60%;
+        text-align: center;
+        border-radius: 5px;
+        color: white;
+        margin : auto;
+    }
+    .div_body{
+        margin: auto;
+        width: 90%;
+        height: 70%;
+        background-color: white;
+        border-radius: 5px;
+        color: black;
+    }
+    .div_header{
+        font-size: 30px;
+        height: 70%;
+        line-height: 75px;
+    }
+    .div_footer{
+        font-size: 15px;
+    }
+    .work_plan_list{
+		height: 40%;
+		line-height: 125px;
+		text-align: center;
+	}
     .workcurrent>button{
     position: absolute;
   	right: 0;
@@ -178,6 +209,6 @@
     height: 30px;
 }
 .comment{
-    overflow-y: scroll;
+    overflow-y: auto;
     height: 300px;
 }

--- a/src/main/resources/static/js/insa/mywork/leave_apply.js
+++ b/src/main/resources/static/js/insa/mywork/leave_apply.js
@@ -58,16 +58,20 @@ $(".modalButton_apply").on("click", function() {
             var managerValue = $(element).val();
             checkedManagerValues.push(managerValue);
         });
-
-        console.log(checkedManagerValues);
-			
+		$('#calendartd').css('display', 'block');
 });
 		 
     });
     // 취소 버튼 클릭 시
     $("#button_cancel_tag").on("click", function(e) {
+		if(selectedDates.length > 0){
+			alert("휴가신청을 삭제한 뒤 시도해주세요");
+			return;
+		}
 		e.preventDefault();
 		$("#approvalTable .innerTable th").text("");
+		$('#leave_apply').css('display', 'none');
+		$('#calendartd').css('display', 'none');
          $(".modal_tag_add").hide();
          $(".modal_background").hide();
     });

--- a/src/main/resources/static/js/insa/mywork/work_leave.js
+++ b/src/main/resources/static/js/insa/mywork/work_leave.js
@@ -4,7 +4,38 @@ var outTimeActivated = false;
 $(document).ready(function() {
 	$(".left_item").load("/insa/manage/left_item?selectItem=work_leave");
 	$("#top_container").load("/commons/topForm");
+	
+	$.ajax({ // 버튼 클릭 시 ajax로 해당 업무 추가
+		url: "/works/workplanlist",
+		
+	}).done(
+		function(resp) {
+			
+		var currentDate = new Date();
+
+        // 월, 일, 요일을 추출합니다.
+        var month = (currentDate.getMonth() + 1).toString().padStart(2, '0'); // 0부터 시작하므로 +1
+        var day = currentDate.getDate().toString().padStart(2, '0');
+        var dayOfWeek = getDayOfWeek(currentDate.getDay());
+        
+        $(".div_body").before(month+"월");
+        $(".div_header").append(day+"일");
+        $(".div_footer").append(dayOfWeek);
+        if(resp==""){
+			$(".work_plan_list").append("9시 출근");
+		}
+		else{
+			 $(".work_plan_list").append(resp);
+		}
+       
+		});
+		
+	
 });
+ function getDayOfWeek(dayNumber) {
+        var daysOfWeek = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
+        return daysOfWeek[dayNumber];
+    }
 function workin() {
 	updateinTime();
 	changeStatus('근무중', this);
@@ -36,6 +67,7 @@ function workout() {
 	}
 
 }
+
 
 function updateinTime() { // 출근하기 클릭 시 시간 출력
 	var currentinTimeArea = document.getElementById("workin");
@@ -107,6 +139,7 @@ function changeStatus(newStatus, button) { // 업무 외출 회의 외근 버튼
 				+ (resp[resp.length - 1].work_type)
 				+ "</td></tr>")
 			$("#workform").append(tr);
+			$('.comment').scrollTop($('.comment')[0].scrollHeight);
 		});
 
 }
@@ -124,12 +157,14 @@ function updateWorkformTable() { // 화면에 근무중 업무중 등 출력하�
 		url: "/works/list",
 	}).done(
 		function(resp) {
+			
 			for (let i = 0; i < resp.length; i++) {
 				let tr = $("<tr>");
 				tr.html("<td width='100'>" + (resp[i].time)
 					+ "</td>" + "<td width='100'>"
 					+ (resp[i].work_type) + "</td></tr>")
 				$("#workform").append(tr);
+				$('.comment').scrollTop($('.comment')[0].scrollHeight);
 			}
 		});
 }

--- a/src/main/resources/static/js/insa/work_manage/workmanage.js
+++ b/src/main/resources/static/js/insa/work_manage/workmanage.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
 
 
 
-		$('.joinday').each(function() {
+		$('.joinday').each(function(e) {
 			const inputValue = $(this).val().trim();
 			// 정규 표현식을 사용하여 YYYY-MM-DD 형식 확인
 			const regex = /^(2000|20[01]\d|202[0-2]|2023)-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
@@ -27,16 +27,16 @@ $(document).ready(function() {
 				const correspondingId = $(this).closest('tr').find('.id').val();
 				idbox.push(correspondingId);
 				joindaybox.push(inputValue);
-			} else if (inputValue !== "") {
+			
+		}else if (inputValue !== "") {
 				// 올바른 형식이 아닌 경우에 대한 처리
 				alert("날짜는 YYYY-MM-DD 형식이어야 하며 2000-01-01부터 입력 가능합니다. ");
 				return;
 			}
 		});
-
-		// 값이 없는 경우에 대한 처리
 		if (joindaybox.length === 0) {
 			alert("날짜를 입력하세요.");
+			e.preventDefault();
 			return;
 		}
 		console.log("idbox:", idbox);

--- a/src/main/webapp/WEB-INF/jsp/insa/left_item.jsp
+++ b/src/main/webapp/WEB-INF/jsp/insa/left_item.jsp
@@ -51,7 +51,7 @@ i{margin-right: 8px;}
 				</div>
 			</div>
 			<!-- 드롭 다운 메뉴 (추가 효과 없음) -->
-			
+			<c:if test="${userDTO.job_name eq '관리'}">
 			<div class="menu_list">
 				<div class="menu_list_button">
 					<div class="menu_list_button_drop">
@@ -71,7 +71,7 @@ i{margin-right: 8px;}
 					</div>
 				</div>
 			</div>
-			
+			</c:if>
 
 			<c:if test="${userDTO.job_name eq '관리'}">
 				<!-- 드롭 다운 메뉴 (추가 효과 없음) -->

--- a/src/main/webapp/WEB-INF/jsp/insa/mywork/leave_apply.jsp
+++ b/src/main/webapp/WEB-INF/jsp/insa/mywork/leave_apply.jsp
@@ -72,24 +72,26 @@
 							</tbody>
 						</table>
 					</div>
+					
+					
+					<div id="calendartd" style="margin-left:24px;display: none;">
 					<h4>휴가 현황</h4>
 					<c:forEach var="i" items="${list }">
-							<h4>잔여 휴가 ${i.leave_remainder}일</h4>
+							<br><h4>잔여 휴가 ${i.leave_remainder}일</h4><br>
 					</c:forEach>
-					
-					<div  
-						style="margin-bottom: 10px; display: flex; align-items: center;">
-						<div style="margin-top: 3px;">
+						<span style="margin-top: 3px;">
 							<img class="prevMonth"
 								src="/images/insa/work_plan/chevron-left.svg">
-						</div>
-						<div class="currentMonth"></div>
-						<div style="margin-top: 3px;">
+						</span>
+						<span class="currentMonth">
+						
+						</span>
+						<span style="margin-top: 3px;">
 							<img class="nextMonth"
 								src="/images/insa/work_plan/chevron-right.svg">
-						</div>
-					</div>
-					<div id="calendartd" style="margin-left: 24px">
+						</span>
+					
+					
 						<table border="1" id="current_table" style="width: 90%;">
 							<thead id="currentTable">
 								<tr id="tr1">
@@ -107,6 +109,7 @@
 							
 							</tbody>
 						</table>
+						</div>
 					</div>
 
 					<div id="leave_apply" style="display: none">

--- a/src/main/webapp/WEB-INF/jsp/insa/mywork/work_leave.jsp
+++ b/src/main/webapp/WEB-INF/jsp/insa/mywork/work_leave.jsp
@@ -88,7 +88,19 @@
 					<div class="spanbox">
 						<span>근무계획</span>
 					</div>
-					<div class="workplanbox"></div>
+					<div class="workplanbox">
+						<div class="calendar_icon">
+							
+							<div class="div_body">
+								<div class="div_header"></div>
+								<div class="div_footer"></div>
+							</div>
+							
+						</div>
+						<div class="work_plan_list">
+							
+						</div>
+					</div>
 				</div>
 				<div class="check">
 					<div class="spanbox">


### PR DESCRIPTION
휴가/근무 페이지에서 근무현황의 스크롤을 아래로 고정했습니다.
직무가 관리가 아니면 근무 관리 기능을 볼 수 없습니다.
전사근무 관리 에서 휴가미생성자의 생성버튼을 클릭 했을 때 실패하여도 다시 입력창으로 돌아옵니다.
근무 계획 ui가 추가 되었습니다.
휴가신청일 선택 시 휴가 선택을 먼저하면 휴가신청 폼이 안뜨던 버그를 수정하였습니다.