### PR TITLE
공통 CSS 업데이트 및 주소록 공통 JS 삭제

### DIFF
--- a/src/main/resources/static/css/commons/body_form/left_form/body_form_default.css
+++ b/src/main/resources/static/css/commons/body_form/left_form/body_form_default.css
@@ -60,7 +60,7 @@
     overflow-x: hidden;
     padding: 0 24px 30px;
     height: 100%;
-    max-height: 785px;
+    max-height: 565px;
 }
 .menu_item {
     height: 38px;

--- a/src/main/resources/static/css/commons/body_form/left_form/body_form_default.css
+++ b/src/main/resources/static/css/commons/body_form/left_form/body_form_default.css
@@ -60,7 +60,7 @@
     overflow-x: hidden;
     padding: 0 24px 30px;
     height: 100%;
-    max-height: 565px;
+    max-height: calc(100% - 228px);
 }
 .menu_item {
     height: 38px;

--- a/src/main/resources/static/js/contact/contact.js
+++ b/src/main/resources/static/js/contact/contact.js
@@ -1383,3 +1383,18 @@ $(document).ready(function() {
 	});
 });
 
+// 메뉴 열고 닫고, 화살표 이미지 회전
+$(document).ready(function() {
+    $(".menu_list_button").click(function() {
+        let parent = $(this).closest('.menu_list');
+        let child = parent.find('.menu_list_box');
+
+        child.toggle();
+        if (child.css('display') === 'none' || child.css('display') === '') {
+            parent.find('.menu_list_button_drop img').css('transform', 'rotate( 180deg )');
+        }
+        else {
+            parent.find('.menu_list_button_drop img').css('transform', '');
+        }
+    });
+});

--- a/src/main/webapp/WEB-INF/jsp/contact/personal.jsp
+++ b/src/main/webapp/WEB-INF/jsp/contact/personal.jsp
@@ -14,7 +14,6 @@
 
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <script src="/js/contact/contact.js"></script>
-<script src="/js/commons/body_form/body_form_default.js"></script>
 
 
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css"

--- a/src/main/webapp/WEB-INF/jsp/contact/share.jsp
+++ b/src/main/webapp/WEB-INF/jsp/contact/share.jsp
@@ -14,7 +14,6 @@
 
 <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
 <script src="/js/contact/contact.js"></script>
-<script src="/js/commons/body_form/body_form_default.js"></script>
 
 
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css"


### PR DESCRIPTION
공통 CSS에서 왼쪽 메뉴 스크롤이 생기기 시작하는 크기 조정하였습니다.
(기존 785px -> 100* 228px로 변경)

공통 JS에 드롭 메뉴를 활용할 떄 레디를 지웠더니 주소록에서 실행되지 않아서
공통 JS를 사용하지 않고 주소록 JS에 옮기고 레디 추가했습니다.